### PR TITLE
Dockerize oplog-replay as worker

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,3 +11,15 @@ notify:
     on_started: true
     on_success: true
     on_failure: true
+publish:
+  docker:
+    docker_port: 4243
+    docker_server: {{docker_server}}
+    docker_version: 1.2
+    email: {{docker_email}}
+    image_name: clever/oplog-replay
+    password: {{docker_password}}
+    push_latest: true
+    registry_login: true
+    username: {{docker_username}}
+    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# oplog-replay worker
+FROM ubuntu:14.04
+RUN apt-get update
+RUN apt-get install -y wget build-essential
+
+# Golang
+RUN apt-get install -y git golang bzr mercurial bash
+RUN GOPATH=/etc/go go get launchpad.net/godeb
+RUN apt-get remove -y golang golang-go golang-doc golang-src
+RUN /etc/go/bin/godeb install 1.2.1
+
+# Oplog replay
+RUN mkdir -p /etc/go/src /github.com/Clever/oplog-replay
+ADD . /etc/go/src/github.com/Clever/oplog-replay
+RUN GOPATH=/etc/go go get github.com/Clever/oplog-replay/...
+RUN GOPATH=/etc/go go build -o /usr/local/bin/oplogreplay github.com/Clever/oplog-replay/cmd/oplog-replay
+
+# Taskwrapper
+RUN mkdir -p /etc/go/src /taskwrapper
+RUN GOPATH=/etc/go go get github.com/Clever/baseworker-go/cmd/taskwrapper
+RUN GOPATH=/etc/go go build -o /usr/local/bin/taskwrapper github.com/Clever/baseworker-go/cmd/taskwrapper
+
+CMD ["/etc/go/src/github.com/Clever/oplog-replay/run_as_worker.sh"]

--- a/cmd/oplog-replay/main.go
+++ b/cmd/oplog-replay/main.go
@@ -22,7 +22,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	input, err := pathio.ReaderForPath(*path)
+	input, err := pathio.Reader(*path)
 	if err != nil {
 		panic(err)
 	}

--- a/run_as_worker.sh
+++ b/run_as_worker.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+taskwrapper --name oplog-replay --cmd /usr/local/bin/oplogreplay --gearman-host $GEARMAN_HOST --gearman-port $GEARMAN_PORT


### PR DESCRIPTION
This change adds a dockerfile to run oplog-replay as a worker. It does
this by using the baseworker-go/taskwrapper code. This listens to
Gearman for requests to process the job.

This change also publishes the docker image to docker hub
