### PR TITLE
Revert godebs version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -y update && apt-get install -y -q curl
 RUN apt-get -y update && apt-get install -y git golang bzr mercurial bash
 RUN GOPATH=/etc/go go get launchpad.net/godeb
 RUN apt-get remove -y golang golang-go golang-doc golang-src
-RUN /etc/go/bin/godeb install 1.5
+RUN /etc/go/bin/godeb install 1.2.1
 
 # Mongo
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10


### PR DESCRIPTION
https://github.com/Clever/oplog-replay/pull/37 Upgraded to 1.5, but that failed to download in drone. Reverting. I tested and this builds in drone successfully. CC: @azylman 